### PR TITLE
feat: add LS_COLORS theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ Pick your preferred theme file, copy it as `~/.config/yazi/theme.toml` or `C:\Us
 
 ## [LS_COLORS](https://github.com/Mellbourn/ls-colors.yazi)
 
-Uses the over 300 different file-type colors from the [LS_COLORS collection](https://github.com/trapd00r/LS_COLORS)
+Uses the over 300 different file-type colors from the [LS_COLORS collection](https://github.com/trapd00r/LS_COLORS) (converted using [lsColorsToToml](https://github.com/Mellbourn/lsColorsToToml))
 
 <img src="https://raw.githubusercontent.com/Mellbourn/ls-colors.yazi/main/Screenshot.png" width="600" />

--- a/README.md
+++ b/README.md
@@ -45,4 +45,6 @@ Pick your preferred theme file, copy it as `~/.config/yazi/theme.toml` or `C:\Us
 
 ## [LS_COLORS](https://github.com/Mellbourn/ls-colors.yazi)
 
+Uses the over 300 different file-type colors from the [LS_COLORS collection](https://github.com/trapd00r/LS_COLORS)
+
 <img src="https://raw.githubusercontent.com/Mellbourn/ls-colors.yazi/main/Screenshot.png" width="600" />

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ Pick your preferred theme file, copy it as `~/.config/yazi/theme.toml` or `C:\Us
 ## [Rosé Pine](https://github.com/Msouza91/rose-pine.yazi)
 
 <img src="https://raw.githubusercontent.com/Msouza91/rose-pine.yazi/main/code-preview.png" width="600" />
+
+## [LS_COLORS](https://github.com/Mellbourn/ls-colors.yazi)
+
+<img src="https://raw.githubusercontent.com/Mellbourn/ls-colors.yazi/main/Screenshot.png" width="600" />

--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ Pick your preferred theme file, copy it as `~/.config/yazi/theme.toml` or `C:\Us
 
 ## [LS_COLORS](https://github.com/Mellbourn/ls-colors.yazi)
 
-Uses the over 300 different file-type colors from the [LS_COLORS collection](https://github.com/trapd00r/LS_COLORS) (converted using [lsColorsToToml](https://github.com/Mellbourn/lsColorsToToml))
+Adds over 300 different colors for filetypes (converted from [the LS_COLORS collection](https://github.com/trapd00r/LS_COLORS) using [lsColorsToToml](https://github.com/Mellbourn/lsColorsToToml))
 
 <img src="https://raw.githubusercontent.com/Mellbourn/ls-colors.yazi/main/Screenshot.png" width="600" />


### PR DESCRIPTION
This will add the LS_COLORS theme to the list of themes in the README.md file. This theme uses the over 300 different file-type colors from the [LS_COLORS collection](https://github.com/trapd00r/LS_COLORS)
