### PR TITLE
docs: remove repository `sachinsenal0x64/crystal-theme` due to HTTP 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ Pick your preferred theme file, copy it as `~/.config/yazi/theme.toml` or `C:\Us
 
 <img src="https://github.com/catppuccin/yazi/raw/main/assets/previews/preview.webp" width="600" />
 
-## [Crystal](https://github.com/sachinsenal0x64/crystal-theme)
-
-<img src="https://raw.githubusercontent.com/sachinsenal0x64/crystal-theme/main/screenshot.png" width="600" />
-
 ## [Gruvbox Dark](https://github.com/poperigby/gruvbox-dark-yazi)
 
 <img src="https://github.com/poperigby/gruvbox-dark-yazi/assets/20866468/219985f5-5dff-4a10-99a5-d41c4adc6ba7" width="600" />


### PR DESCRIPTION
For some reason, https://github.com/sachinsenal0x64/crystal-theme has disappeared from the internet, and even [@sachinsenal0x64](https://github.com/sachinsenal0x64) is 404.

![1](https://github.com/yazi-rs/flavors/assets/17523360/2e0c370b-1fef-411c-b106-8e0b87789da0)


This PR removes it from the README because it's no longer accessible. I'll wait for a while before merging it, in case you can see this PR and get in touch with us. @sachinsenal0x64