### PR TITLE
feat: add new theme ayu-dark

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ Pick your preferred theme file, copy it as `~/.config/yazi/theme.toml` or `C:\Us
 Adds over 300 different colors for filetypes (converted from [the LS_COLORS collection](https://github.com/trapd00r/LS_COLORS) using [lsColorsToToml](https://github.com/Mellbourn/lsColorsToToml))
 
 <img src="https://raw.githubusercontent.com/Mellbourn/ls-colors.yazi/main/Screenshot.png" width="600" />
+
+## [Ayu Dark](https://github.com/kmlupreti/ayu-dark.yazi)
+
+<img src="https://raw.githubusercontent.com/kmlupreti/ayu-dark.yazi/main/preview.png" width="600" />


### PR DESCRIPTION
It adds Ayu dark theme flavor based on tmtheme.xml xml obtained from [dempfi/ayu](https://github.com/dempfi/ayu) sublime text color scheme. This specific tmtheme.xml file have been obtained from [ v4.0.0](https://github.com/dempfi/ayu/archive/refs/tags/4.0.0.zip). The flavor.toml has been adjusted to match to ayu dark theme as much as possible and will be further improved on.
 
## preview  image
![image](https://github.com/user-attachments/assets/7931d295-d076-40d3-9884-f2c5669e2b95)
