### PR TITLE
Add fly16 flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ See https://yazi-rs.github.io/docs/flavors/overview for details.
 
 <img src="./catppuccin-macchiato.yazi/preview.png" width="600" />
 
+## [fly16.yazi](https://github.com/tkapias/fly16.yazi)
+
+<img src="https://raw.githubusercontent.com/tkapias/fly16.yazi/main/preview.png" width="600" />
+
 ## [onedark.yazi](https://github.com/BennyOe/onedark.yazi)
 
 <img src="https://raw.githubusercontent.com/BennyOe/onedark.yazi/main/preview.png" width="600" />


### PR DESCRIPTION
I used the tmtheme.xml file from [fly16](https://github.com/bluz71/fly16-bat) to create a flavor suitable for the [moonfly](https://github.com/bluz71/vim-moonfly-colors) & [nightfly](https://github.com/bluz71/vim-nightfly-guicolors) Vim/Neovim colorschemes (and their associated terminal themes).