### PR TITLE
fix: replace fly16 flavor by nightfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ See https://yazi-rs.github.io/docs/flavors/overview for details.
 
 <img src="./catppuccin-macchiato.yazi/preview.png" width="600" />
 
-## [fly16.yazi](https://github.com/tkapias/fly16.yazi)
+## [nightfly.yazi](https://github.com/tkapias/nightfly.yazi)
 
-<img src="https://raw.githubusercontent.com/tkapias/fly16.yazi/main/preview.png" width="600" />
+<img src="https://raw.githubusercontent.com/tkapias/nightfly.yazi/main/preview.png" width="600" />
 
 ## [onedark.yazi](https://github.com/BennyOe/onedark.yazi)
 


### PR DESCRIPTION
Sorry, but I was too hasty in making a new flavor named fly16 in PR #29 .

The original author bluz71 has since [pointed out](https://github.com/bluz71/vim-nightfly-colors/issues/63) to me that the .tmTheme file I used was based on the current terminal colors and that in addition it would be necessary to make 2 flavors for the 2 styles related to it: [moonfly](https://github.com/bluz71/vim-moonfly-colors) and [nightfly](https://github.com/bluz71/vim-nightfly-colors).

So I remade a new flavor dedicated to nightfly with dedicated color codes.

This PR replaces fly16.yazi, which is therefore erroneous, by nightfly.yazi.