### PR TITLE
fix: update ashen repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See https://yazi-rs.github.io/docs/flavors/overview for details.
 
 <img src="https://gitlab.com/aimebertrand/timu-macos-yazi/-/raw/main/timu-macos-light.yazi/preview.png" width="600" />
 
-## [Ashen](https://github.com/ashen-org/ashen/tree/main/ashen.yazi)
+## [Ashen](https://github.com/ficcdaf/ashen/tree/main/ashen.yazi)
 
 <img src="https://raw.githubusercontent.com/ashen-org/ashen/refs/heads/main/ashen.yazi/preview.png" width="600" />
 


### PR DESCRIPTION
I recently moved the Ashen theme from `ashen-org` back to my own account. While redirects are set up currently, this isn't guaranteed to remain, so I've updated the URL that points to Ashen Yazi flavor.
