### PR TITLE
feat: add vscode flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ See https://yazi-rs.github.io/docs/flavors/overview for details.
 
 <img src="https://raw.githubusercontent.com/gosxrgxx/flexoki-light.yazi/main/preview.png" width="600" />
 
+## [vscode-dark-modern](https://github.com/956MB/vscode-dark-modern.yazi)
+
+<img src="https://raw.githubusercontent.com/956MB/vscode-dark-modern.yazi/refs/heads/main/img/preview.png" width="600" />
+
+## [vscode-light-modern](https://github.com/956MB/vscode-light-modern.yazi)
+
+<img src="https://raw.githubusercontent.com/956MB/vscode-light-modern.yazi/refs/heads/main/img/preview.png" width="600" />
+
+## [vscode-dark-plus](https://github.com/956MB/vscode-dark-plus.yazi)
+
+<img src="https://raw.githubusercontent.com/956MB/vscode-dark-plus.yazi/refs/heads/main/img/preview.png" width="600" />
+
+## [vscode-light-plus](https://github.com/956MB/vscode-light-plus.yazi)
+
+<img src="https://raw.githubusercontent.com/956MB/vscode-light-plus.yazi/refs/heads/main/img/preview.png" width="600" />
+
 ## Themes
 
 We [recommend using the new flavor format](https://yazi-rs.github.io/docs/flavors/overview/#why), but if you're still interested in themes, check out the [Themes](./themes.md) page.


### PR DESCRIPTION
Adds dark and light variants (modern/plus) of Visual Studio Code's default themes.

(It could also be just a link to [vscode.yazi](https://github.com/956MB/vscode.yazi) which has them all instead of 4 taking up more space in the README, like below.)

```markdown
## [vscode.yazi](https://github.com/956MB/vscode.yazi)

<img src="https://raw.githubusercontent.com/956MB/vscode-dark-modern.yazi/refs/heads/main/img/preview.png" width="600" />
```