### PR TITLE
feat: add thinkpad-red-oled flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ This is a flavor which uses terminal colors, so it works with any terminal theme
 
 <img src="https://raw.githubusercontent.com/rapidrabbit76/claude-inspired.yazi/main/preview.png" width="600" />
 
+## [thinkpad-red-oled.yazi](https://github.com/AdmiralBarbarossa/thinkpad-red-oled.yazi)
+
+<img src="https://raw.githubusercontent.com/AdmiralBarbarossa/thinkpad-red-oled.yazi/main/preview.png" width="600" />
+
 ## Themes
 
 We [recommend using the new flavor format](https://yazi-rs.github.io/docs/flavors/overview/#why-flavor), but if you're still interested in themes, check out the [Themes](./themes.md) page.


### PR DESCRIPTION
I would like to add a new [flavor](https://github.com/AdmiralBarbarossa/thinkpad-red-oled.yazi) to the `README.md` list.

This flavor is a minimalistic and high-contrast theme optimal for OLED displays. It uses a pure black background (`#000000`) with strict ThinkPad Red (`#b9162a`) accents and sharp corners.

Moreover, the `flavor.toml` file has been validated using `taplo`.

Thank you for building such an amazing file manager!